### PR TITLE
Including PATCH request body parameters in the mock data resource names.

### DIFF
--- a/VOKMockUrlProtocol.m
+++ b/VOKMockUrlProtocol.m
@@ -78,7 +78,8 @@ static NSString *const MockDataDirectory = @"VOKMockData";
     if (self.request.URL.query) {
         [resourceName appendFormat:@"?%@", self.request.URL.query];
     }
-    if ([kHTTPMethodPost isEqualToString:self.request.HTTPMethod]) {
+    if ([kHTTPMethodPost isEqualToString:self.request.HTTPMethod]
+        || [kHTTPMethodPatch isEqualToString:self.request.HTTPMethod]) {
         [resourceName appendFormat:@"|%@",
          [[NSString alloc] initWithData:self.request.HTTPBody
                                encoding:NSUTF8StringEncoding]];

--- a/VOKMockUrlProtocol.podspec
+++ b/VOKMockUrlProtocol.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name         = "VOKMockUrlProtocol"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.platform     = :ios
   s.ios.deployment_target = "6.0"
   s.summary      = "A url protocol that parses and returns fake responses with mock data."
   s.homepage     = "https://github.com/vokalinteractive/VOKMockUrlProtocol"
   s.license      = { :type => "MIT", :file => "LICENSE"}
   s.author       = { "VOKAL Interactive" => "hello@vokalinteractive.com" }
-  s.source       = { :git => "https://github.com/vokalinteractive/VOKMockUrlProtocol.git", :tag => "1.0.0" }
+  s.source       = { :git => "https://github.com/vokalinteractive/VOKMockUrlProtocol.git", :tag => "1.0.1" }
   s.source_files = "*.{h,m}"
   s.requires_arc = true
   s.dependency 'ILGHttpConstants', '~> 1.0.0'


### PR DESCRIPTION
Please tag as `1.0.1` when merged.
