### PR TITLE
Oh, Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 xcode_workspace: Example/VOKMockUrlProtocol.xcworkspace
 xcode_scheme: VOKMockUrlProtocol
+xcode_sdk: iphonesimulator
 before_install:
-  - brew update
-  - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
+  - brew update > /dev/null; if brew outdated | grep -qx xctool; then brew upgrade xctool; fi


### PR DESCRIPTION
The default image on Travis no longer has the 8.0 SDK available, so maybe if I just don't specify an SDK, things won't break like this?
