### PR TITLE
protocolClasses is already copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ Example:
     Class mockURLProtocol = [VOKMockUrlProtocol class];
     NSMutableArray *currentProtocolClasses = [self.sessionConfiguration.protocolClasses mutableCopy];
     [currentProtocolClasses insertObject:mockURLProtocol atIndex:0];
-    self.sessionConfiguration.protocolClasses = [currentProtocolClasses copy];
+    self.sessionConfiguration.protocolClasses = currentProtocolClasses;
 ```
 In order to switch back and forth between mock and live, you can also take out the Mock Url Protocol by just removing it:
 ```
     Class mockURLProtocol = [VOKMockUrlProtocol class];
     NSMutableArray *currentProtocolClasses = [self.sessionConfiguration.protocolClasses mutableCopy];
     [currentProtocolClasses removeObject:mockURLProtocol];
-    self.sessionConfiguration.protocolClasses = [currentProtocolClasses copy];
+    self.sessionConfiguration.protocolClasses = currentProtocolClasses;
   ```


### PR DESCRIPTION
Per @chillpop: `protocolClasses` is already marked `copy`