### PR TITLE
Make sure the protocol classes array isn't nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In order to get `NSURLSesssion` to use `VOKMockUrlProtocol`, you must insert its
 Example:
 ```
     Class mockURLProtocol = [VOKMockUrlProtocol class];
-    NSMutableArray *currentProtocolClasses = [self.sessionConfiguration.protocolClasses mutableCopy];
+    NSMutableArray *currentProtocolClasses = [self.sessionConfiguration.protocolClasses mutableCopy] ?: [NSMutableArray array];
     [currentProtocolClasses insertObject:mockURLProtocol atIndex:0];
     self.sessionConfiguration.protocolClasses = currentProtocolClasses;
 ```


### PR DESCRIPTION
Related to my earlier PR on another (private) repo: `protocolClasses` property can be nil.

@vokal/ios-developers cool?