### PR TITLE
Modifies VOKMockUrlProtocol to allow for custom directory names

### DIFF
--- a/VOKMockUrlProtocol.h
+++ b/VOKMockUrlProtocol.h
@@ -12,4 +12,11 @@
  */
 @interface VOKMockUrlProtocol : NSURLProtocol
 
+/**
+ *  Mock data should go into a directory with the name defined in this string.
+ *  It defaults to "VOKMockData", but its default can be overwritten by subclassing
+ *  VOKMockUrlProtocol and overriding - initWithRequest:cachedResponse:client.
+ */
+@property (strong, nonatomic) NSString *mockDataDirectory;
+
 @end

--- a/VOKMockUrlProtocol.m
+++ b/VOKMockUrlProtocol.m
@@ -23,7 +23,7 @@
     #endif
 #endif
 
-static NSString *const MockDataDirectory = @"VOKMockData";
+static NSString *const DefaultMockDataDirectory = @"VOKMockData";
 
 static NSString *const AppendSeparatorFormat = @"|%@";
 
@@ -48,6 +48,19 @@ static NSInteger const MaxBaseFilenameLength = NAME_MAX - 5;
 #pragma mark -
 
 @implementation VOKMockUrlProtocol
+
+- (instancetype)initWithRequest:(NSURLRequest *)request
+                 cachedResponse:(NSCachedURLResponse *)cachedResponse
+                         client:(id<NSURLProtocolClient>)client
+{
+    if (self = [super initWithRequest:request
+                       cachedResponse:cachedResponse
+                               client:client]) {
+        self.mockDataDirectory = DefaultMockDataDirectory;
+    }
+    
+    return self;
+}
 
 + (BOOL)canInitWithRequest:(NSURLRequest *)request
 {
@@ -314,7 +327,7 @@ static NSInteger const MaxBaseFilenameLength = NAME_MAX - 5;
     for (NSString *resourceName in resourceNames) {
         filePath = [[NSBundle bundleForClass:[self class]] pathForResource:resourceName
                                                                     ofType:@"http"
-                                                               inDirectory:MockDataDirectory];
+                                                               inDirectory:self.mockDataDirectory];
         NSString *fileContents = [NSString stringWithContentsOfFile:filePath
                                                            encoding:NSUTF8StringEncoding
                                                               error:NULL];
@@ -329,7 +342,7 @@ static NSInteger const MaxBaseFilenameLength = NAME_MAX - 5;
     for (NSString *resourceName in resourceNames) {
         filePath = [[NSBundle bundleForClass:[self class]] pathForResource:resourceName
                                                                     ofType:@"json"
-                                                               inDirectory:MockDataDirectory];
+                                                               inDirectory:self.mockDataDirectory];
         NSData *data = [NSData dataWithContentsOfFile:filePath];
         if (data) {
             // We've got a JSON data file, so send it.


### PR DESCRIPTION
This PR modifies VOKMockUrlProtocol to allow for custom directory names for mock data.

It sets the default directory name to the forced name from before. You can easily change the directory name by subclassing VOKMockUrlProtocol and overriding -initWithRequest:cachedResponse:client and setting the directory name in that method. This offers the advantage of being able to change mocked server responses based on conditions.

@vokal/ios-developers code review please :)