### PR TITLE
Enable OS X as a platform in the pod and bump the version.

### DIFF
--- a/VOKMockUrlProtocol.podspec
+++ b/VOKMockUrlProtocol.podspec
@@ -1,13 +1,14 @@
 Pod::Spec.new do |s|
   s.name             = "VOKMockUrlProtocol"
-  s.version          = "2.1.0"
+  s.version          = "2.1.1"
   s.summary          = "A url protocol that parses and returns fake responses with mock data."
   s.homepage         = "https://github.com/vokal/VOKMockUrlProtocol"
   s.license          = { :type => "MIT", :file => "LICENSE"}
   s.author           = { "Vokal" => "hello@vokalinteractive.com" }
   s.source           = { :git => "https://github.com/vokal/VOKMockUrlProtocol.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '6.0'
+  s.ios.platform      = :ios, '6.0'
+  s.osx.platform      = :osx, '10.9'
   s.requires_arc = true
 
   s.source_files = 'VOKMockUrlProtocol.[hm]'


### PR DESCRIPTION
Does what it says on the tin.  As far as I can tell, there's no issue with using VOKMockUrlProtocol on OS X.

@vokal/ios-developers Review please?