### PR TITLE
Add ability to use auth header as part of file name 

### DIFF
--- a/Example/VOKMockData/GET|-auth&authorization=Token%20I_am_a_token.http
+++ b/Example/VOKMockData/GET|-auth&authorization=Token%20I_am_a_token.http
@@ -1,0 +1,3 @@
+HTTP/1.1 202 Accepted
+
+{"favorite_dog_breed": "dogfish"}

--- a/Example/VOKMockUrlProtocol/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/VOKMockUrlProtocol/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,8 +7,18 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
     },
     {
       "idiom" : "iphone",
@@ -16,6 +26,11 @@
       "scale" : "2x"
     },
     {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
       "idiom" : "ipad",
       "size" : "29x29",
       "scale" : "1x"
@@ -43,6 +58,11 @@
     {
       "idiom" : "ipad",
       "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
       "scale" : "2x"
     }
   ],

--- a/README.md
+++ b/README.md
@@ -86,3 +86,7 @@ In order to switch back and forth between mock and live, you can also take out t
 ### Using with Frameworks/Swift
 
 When `VOKMockUrlProtocol` is built as a framework (usually for use with Swift), make sure to call the `setTestBundle:` class method and pass in your test bundle. Since the default behavior is to fall back to the bundle for the current class, that would look in the Framework's bundle rather than the test bundle, and nothing would work.
+
+### Using with HTTP Authorization headers
+
+To verify that authorization headers are being sent properly, make sure to set `setShouldEncodeAuthHeader` to YES. This will verify that the value for the http header "Authorization" is set to an expected value. Otherwise, auth headers will not be verified. 

--- a/VOKMockUrlProtocol.h
+++ b/VOKMockUrlProtocol.h
@@ -20,4 +20,12 @@
  */
 + (void)setTestBundle:(NSBundle *)bundle;
 
+/**
+ *  Allows you to encode authorizatation headers if desired. Defaults to NO.
+ *
+ *  @param encodeAuthHeader YES to encode the `Authorization` header as part of 
+ *                          the filename, NO to not do that.
+ */
++ (void)setShouldEncodeAuthHeader:(BOOL)encodeAuthHeader;
+
 @end

--- a/VOKMockUrlProtocol.m
+++ b/VOKMockUrlProtocol.m
@@ -11,6 +11,7 @@
 
 #import <ILGHttpConstants/HTTPStatusCodes.h>
 #import <ILGHttpConstants/HTTPMethods.h>
+#import <ILGHttpConstants/HttpHeaderFields.h>
 #import <VOKBenkode/VOKBenkode.h>
 #import <sys/syslimits.h>
 
@@ -53,6 +54,12 @@ static NSBundle *testBundle = nil;
 + (void)setTestBundle:(NSBundle *)bundle
 {
     testBundle = bundle;
+}
+
+static BOOL shouldEncodeAuthHeader = NO;
++ (void)setShouldEncodeAuthHeader:(BOOL)encodeAuthHeader
+{
+    shouldEncodeAuthHeader = encodeAuthHeader;
 }
 
 + (BOOL)canInitWithRequest:(NSURLRequest *)request
@@ -109,6 +116,16 @@ static NSBundle *testBundle = nil;
         [resourceNames addObject:[[resourceName stringByAppendingFormat:queryFormat, hashedQuery] mutableCopy]];
         
         [resourceName appendFormat:queryFormat, self.request.URL.query];
+    }
+    
+    if (shouldEncodeAuthHeader) {
+        NSDictionary *headerDict = self.request.allHTTPHeaderFields;
+        NSString *authHeader = headerDict[kHTTPHeaderFieldAuthorization];
+        if (authHeader) {
+            NSString *encodedHeader = [authHeader stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+            NSString *authString = [NSString stringWithFormat:@"&authorization=%@", encodedHeader];
+            [resourceName appendString:authString];
+        }
     }
     
     // If the request is one that can have a body...

--- a/VOKMockUrlProtocol.podspec
+++ b/VOKMockUrlProtocol.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "VOKMockUrlProtocol"
-  s.version          = "2.2.0"
+  s.version          = "2.2.1"
   s.summary          = "A url protocol that parses and returns fake responses with mock data."
   s.homepage         = "https://github.com/vokal/VOKMockUrlProtocol"
   s.license          = { :type => "MIT", :file => "LICENSE"}


### PR DESCRIPTION
Allows verification of auth header if the consumer so desires. 